### PR TITLE
fix 更新反代脚本，解决文件列表接口有时相应400的问题

### DIFF
--- a/cf-worker/index.js
+++ b/cf-worker/index.js
@@ -71,7 +71,7 @@ addEventListener('fetch', event => {
                 }
             }
             // 发起 fetch
-            let fr = (await fetch(url, fp));
+            let fr = (await fetch(new URL(url), fp));
             outCt = fr.headers.get('content-type');
             if(outCt && (outCt.includes('application/text') || outCt.includes('text/html'))) {
               try {


### PR DESCRIPTION
有时刷新会出现400错误，文件列表无法加载。在本地使用curl和fetch对原接口发起访问都没有问题，确定官方接口参数没有变更。最后调试发现在cloudflare的worker脚本发起请求有机率会响应400。而且只有带filters参数的文件列表接口才有问题，filters参数是一个在url查询参数中的json对象。猜测cloudflare运行脚本的各个服务器的fetch版本不一致，对url中的encode后的json处理方式有区别。原先脚本是直接将请求前端请求url字符串作为fetch第一个参数。现在改成先new URL对象，再将对象作为fetch参数，这个时候console.log观察URL对象的searchParams解析正常。而fetch对URL对象的解析在各版本中应该比较稳定一致，所以没有出现400的问题了